### PR TITLE
Generate KPI Dictionary

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,8 @@
 - [Environment Configuration](ENV.md) - Environment variables setup
 - [Docker Setup](DOCKER.md) - Docker configuration details
 - [Production Deployment](PRODUCTION.md) - Production deployment guide
+- [`KPI Dictionary`](kpi_dictionary_en.md) - Definitions, formulas, assumptions, and edge cases for KPIs
+- [`Diccionario de KPIs`](kpi_dictionary_es.md) - Definiciones, fórmulas, supuestos y casos borde de los KPIs.
 
 ## 🛠️ Development
 

--- a/kpi_dictionary_en.md
+++ b/kpi_dictionary_en.md
@@ -1,0 +1,116 @@
+# KPI Dictionary (v1.1) — PostgreSQL/TimescaleDB + Django/Celery + Grafana
+
+KPIs are computed/stored in **PostgreSQL/TimescaleDB** by **Django/Celery** jobs and visualized in **Grafana via SQL**.
+
+## Scope & Data Pipeline
+- **Sources**
+  - **GTFS Schedule (PostgreSQL)**: `routes`, `trips`, `stop_times`, `calendar`, `calendar_dates`.
+  - **GTFS‑Realtime / Infobús**: `vehicle_positions`, `trip_updates` (when available), `header.timestamp`.
+- **Pipeline**
+  - **Django + Celery** ingest/transform at fixed intervals (e.g., 5–30 s for RT, 5–15 min for aggregates).
+  - Data lands in **TimescaleDB hypertables** (e.g., `arrivals`, `feed_status`).
+  - KPIs are exposed via **SQL views** / **continuous aggregates** and consumed directly in Grafana panels.
+- **Timezone**: America/Costa_Rica.
+- **Rolling Windows (suggested)**
+  - Delay/OTP: **15 min** (`delay_window_s`).
+  - Headway/gaps: **30 min** (`headway_window_s`).
+
+## Schema & Naming (suggested)
+- `arrivals(route_id, stop_id, trip_id, scheduled_ts, actual_ts, delay_s, observed_at)` — one row per observed arrival (or per control-point event).
+- `scheduled_headways(route_id, stop_id, timeband, headway_s, valid_from, valid_to)` — precomputed schedule headways by band.
+- `feed_status(source, last_header_ts, last_seen_ts)` — latest GTFS‑RT status per source.
+- `occupancy(route_id, vehicle_id, ratio, observed_at)` — when available.
+
+---
+
+## KPI 1 — On‑Time Performance (OTP, %)
+**Definition**: Compare actual arrivals and departures against planned ones.
+Share of events with absolute delay ≤ threshold (e.g., 60 s).  
+**Formula**  
+\[
+OTP(\%) = \frac{|\{e\in E : |delay_e| \le \theta\}|}{|E|} \times 100
+\]
+with \( delay_e = t^{real}_e - t^{sched}_e \) and \(\theta\) = punctuality threshold (default 60 s).  
+**Inputs**: scheduled time (`stop_times.arrival_time`) vs. real time (from `trip_updates` or stop pass inference).  
+**Units**: percent (0–100).  
+**Metric**: `pt_on_time_percentage{route_id}` *(Gauge)*.  
+**Assumptions**: early events (negative delay) count if |delay| ≤ θ; configurable threshold.  
+**Edge cases**: pickup/drop‑off only stops; few events in window — report `sample_size` or suppress when |E| < N_min.
+
+---
+
+## KPI 2 — Average Delay (s)
+**Definition**: Average Delay would refer to the typical deviation from the planned schedule, calculated in seconds, where a positive value means bus is late and a negative value means it's early.   
+**Formula**  
+\[
+\overline{delay} = \frac{1}{|E|}\sum_{e\in E}(t^{real}_e - t^{sched}_e)
+\]
+**Units**: seconds (may be negative).  
+**Metric**: `pt_average_delay_seconds{route_id}` *(Gauge)*.  
+**Assumptions**: trim outliers (e.g., percentiles 1–99 or |delay| ≤ 1800 s).  
+**Edge cases**: short‑turns, partial trips, schedule changes.
+
+---
+
+## KPI 3 — Headway Adherence (ratio)
+**Definition**: Refers to the comparison of actual vehicle headways (time between consecutive vehicles) against scheduled headways to measure service regularity. 
+**Formula**  
+\[
+Headway_Adherence(ratio) = Observed headway / scheduled headway at control points.
+\]
+BUNCHING: When vehicles are much closer together than scheduled. 
+GAPPING: When there is a larger-than-expected gap between vehicles.   
+**How**:  
+- **Scheduled**: derive headway from `stop_times` for time band (peak/off‑peak) at chosen `stop_id`.  
+- **Observed**: deltas between consecutive real arrivals at that `stop_id`.  
+**Units**: ratio (1.0 ideal; >1.0 gaps; <1.0 bunching risk).  
+**Metric**: `pt_headway_adherence_ratio{route_id}` (optionally `stop_id`).  
+**Assumptions**: need ≥3 arrivals in window for stability; exclude layovers.  
+**Edge cases**: terminals with multiple in/out passes; irregular headways.
+
+---
+
+## KPI 4 — Feed Freshness (s)
+**Definition**: Age of GTFS‑RT feed.  
+**Formula**  
+\[
+freshness\_s = now() - header.timestamp
+\]
+**Units**: seconds.  
+**Metric**: `pt_feed_age_seconds`.  
+**Assumptions**: server clock synced (NTP).  
+**Edge cases**: missing/future timestamps — emit NaN/omit and alert.
+
+---
+
+## KPI 5 — Service Gaps (count)
+**Definition**: Missing or incomplete portion of a transit agency's scheduled or real-time services that are not accurately represented or published within their GTFS data. 
+Count of periods with no bus observed **> k × scheduled headway**.  
+**Concept**  
+\[
+gap = \mathbb{1}\{t_{no\_vehicles} > k \cdot headway_{sched}\}
+\]
+accumulated within window.  
+**Units**: integer count.  
+**Metric**: `pt_service_gaps_count{route_id}`.  
+**Assumptions**: k - TBD (`service_gap_factor`) 
+**Edge cases**: off‑service hours — use calendar to avoid false positives.
+
+---
+
+## KPI 6 — Occupancy (ratio, if available)
+**Definition**: Vehicle load factor 0..1.  
+**Computation**:  
+- If feed exposes `occupancy_percentage` → use 0..1 (or convert 0..100%).  
+- If only `occupancy_status` (discrete), map to ratio (e.g., `MANY_SEATS_AVAILABLE` ≈ 0.2, `FEW_SEATS_AVAILABLE` ≈ 0.8, `FULL` = 1.0).  
+**Metric**: `pt_occupancy_ratio{route_id}` (or by vehicle if needed).  
+**Assumptions**: do not emit when missing.  
+**Edge cases**: heterogeneous agency conventions; sparse sampling.
+
+---
+
+## Data Quality & Validation
+- Clock sync (NTP); stable identifiers (`route_id`, `stop_id`).
+- Report `sample_size` for transparency when low.
+- Validate OTP/Delay by time‑of‑day; headways at named control points.
+- Keep **view** names stable for Grafana dashboards.

--- a/kpi_dictionary_es.md
+++ b/kpi_dictionary_es.md
@@ -1,0 +1,113 @@
+# Diccionario de KPIs (v1.1) — PostgreSQL/TimescaleDB + Django/Celery + Grafana
+
+**PostgreSQL/TimescaleDB** mediante tareas de **Django/Celery** y se visualizan en **Grafana con SQL**.
+
+## Alcance y flujo de datos
+- **Fuentes**
+  - **GTFS Schedule (PostgreSQL)**: `routes`, `trips`, `stop_times`, `calendar`, `calendar_dates`.
+  - **GTFS‑RT / Infobús**: `vehicle_positions`, `trip_updates` (cuando exista), `header.timestamp`.
+- **Pipeline**
+  - **Django + Celery** ingiere/transforma en intervalos fijos (p. ej., 5–30 s para RT, 5–15 min para agregados).
+  - Los datos se guardan en **hypertables de TimescaleDB** (p. ej., `arrivals`, `feed_status`).
+  - Los KPIs se exponen mediante **vistas SQL** / **agregados continuos** y Grafana los consume por SQL.
+- **Zona horaria**: America/Costa_Rica.
+- **Ventanas sugeridas**
+  - Demora/OTP: **15 min** (`delay_window_s`).
+  - Headway/gaps: **30 min** (`headway_window_s`).
+
+## Esquema y nombres (sugeridos)
+- `arrivals(route_id, stop_id, trip_id, scheduled_ts, actual_ts, delay_s, observed_at)` — una fila por llegada observada (o evento en punto de control).
+- `scheduled_headways(route_id, stop_id, timeband, headway_s, valid_from, valid_to)` — headways programados por franja.
+- `feed_status(source, last_header_ts, last_seen_ts)` — estado reciente del feed GTFS‑RT por fuente.
+- `occupancy(route_id, vehicle_id, ratio, observed_at)` — cuando exista.
+
+---
+
+## KPI 1 — On‑Time Performance (OTP, %)
+**Definición**: Comparación de llegadas y salidas reales contra horario planeado. Porcentaje de eventos con |demora| ≤ umbral (p. ej. 60 s).  
+**Fórmula**  
+\[
+OTP(\%) = \frac{|\{e\in E : |delay_e| \le \theta\}|}{|E|} \times 100
+\]
+Donde \( delay_e = t^{real}_e - t^{prog}_e \) y \(\theta\) = umbral de puntualidad (pendiente de definir).  
+**Entradas**: hora programada (`stop_times.arrival_time`) vs hora real (de `trip_updates` o inferida por paso).  
+**Unidades**: porcentaje (0–100).  
+**Métrica**: `pt_on_time_percentage{route_id}` *(Gauge)*.  
+**Supuestos**: eventos tempranos (delay < 0) cuentan si |delay| ≤ θ; umbral configurable.  
+**Casos borde**: paradas solo pick‑up/drop‑off; pocas observaciones — reportar `sample_size` o suprimir si |E| < N_min.
+
+---
+
+## KPI 2 — Demora promedio (s)
+**Definición**: La demora promedio se refiere a la desviación del horario planificado, calculada en segundos; un valor positivo indica que el bus está retrasado y uno negativo que está adelantado.
+**Fórmula**  
+\[
+\overline{delay} = \frac{1}{|E|}\sum_{e\in E}(t^{real}_e - t^{prog}_e)
+\]
+**Unidades**: segundos (puede ser negativo).  
+**Métrica**: `pt_average_delay_seconds{route_id}` *(Gauge)*.  
+**Supuestos**: recortar valores atípicos (p. ej., percentiles 1–99 o |delay| ≤ 1800 s). Usar ventana de tiempo para el calculo, medir promedio por ruta. 
+
+
+---
+
+## KPI 3 — Cumplimiento de headway (ratio)
+**Definición**: Se refiere a la comparación de los intervalos de tiempo reales entre vehículos (tiempo entre vehículos consecutivos) frente a los intervalos programados para medir la regularidad del servicio.
+
+headway(ratio) = headway observado / headway programado en puntos de control.  
+
+BUNCHING (agrupamiento): cuando los vehículos (buses) circulan mucho más cerca entre sí de lo programado.
+GAPPING (brecha/hueco de servicio): cuando hay un intervalo de tiempo entre vehículos mayor al esperado.
+**Cómo**:  
+- **Programado**: usar `stop_times` para la ventana de tiempo en el `stop_id` elegido.  
+- **Observado**: diferencias entre llegadas reales consecutivas en ese `stop_id`.  
+**Unidades**: adimensional (1.0 ideal; >1.0 huecos; <1.0 riesgo de bunching).  
+**Métrica**: `pt_headway_adherence_ratio{route_id}`  (opcional `stop_id`).  
+**Supuestos**: ≥3 llegadas en la ventana; excluir layovers.  
+**Casos borde**: terminales con múltiples entradas/salidas; headways irregulares.
+
+---
+
+## KPI 4 — Frescura del feed (s)
+**Definición**: antigüedad del GTFS‑RT.  
+**Fórmula**  
+\[
+freshness\_s = now() - header.timestamp
+\]
+**Unidades**: segundos.  
+**Métrica**: `pt_feed_age_seconds`.  
+**Supuestos**: reloj del servidor sincronizado (NTP).  
+**Casos borde**: timestamps ausentes o futuros — emitir NaN/omitir y alertar.
+
+---
+
+## KPI 5 — Huecos de servicio (conteo)
+**Definición**: número de periodos sin vehículos observados **> k × headway programado**.  
+**Concepto**  
+\[
+gap = \mathbb{1}\{t_{sin\_vehículos} > k \cdot headway_{prog}\}
+\]
+acumulado en la ventana.  
+**Unidades**: entero.  
+**Métrica**: `pt_service_gaps_count{route_id}`.  
+**Parámetros**: por defecto \(k=2\) (`service_gap_factor`) y un piso `service_gap_min_headway_s`.  
+**Casos borde**: horas fuera de servicio — usar calendario para evitar falsos positivos.
+
+---
+
+## KPI 6 — Ocupación (ratio, si disponible)
+**Definición**: nivel de ocupación 0..1.  
+**Cálculo**:  
+- Si hay `occupancy_percentage`, usar 0..1 (o convertir 0–100%).  
+- Si solo hay `occupancy_status`, mapear a ratio (p. ej., `MANY_SEATS_AVAILABLE` ≈ 0.2, `FEW_SEATS_AVAILABLE` ≈ 0.8, `FULL` = 1.0).  
+**Métrica**: `pt_occupancy_ratio{route_id}`  (o por vehículo si aplica).  
+**Supuestos**: no emitir cuando no exista dato.  
+**Casos borde**: convenciones distintas entre agencias; muestreo esporádico.
+
+---
+
+## Calidad de datos y validación
+- Reloj sincronizado (NTP); identificadores estables (`route_id`, `stop_id`).
+- Reportar `sample_size` cuando sea bajo.
+- Validar OTP/Demora por franja horaria; headways en puntos de control definidos.
+- Mantener nombres de **vistas** estables para paneles de Grafana.


### PR DESCRIPTION
docs(kpi): add KPI Dictionary (EN/ES) v1.1

- Defines OTP, headway adherence, average delay, feed freshness, service gaps, and occupancy (if available)
- Includes formulas, assumptions, edge cases; suggested windows 
- Adds README links

Tasks:

- [x] Written dictionary with formulas and assumptions
- [x] Edge cases noted
- [x] Linked in README

Closes #3